### PR TITLE
Fixed checkout layout

### DIFF
--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<body>
     	<referenceContainer name="additional.product.info">
        		 <block class="Magento\Framework\View\Element\Template" name="minicart.refresh" template="Sapient_Worldpay::checkout/cart/minicartrefresh.phtml"/>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.root">
             <arguments>


### PR DESCRIPTION
By default checkout_index_index has layout="checkout", module shouldn't change it to 1column. Also removed layout definition from checkout_cart_index.