### PR TITLE
Checkout billing step rendering issues fix

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -13,7 +13,7 @@ var config = {
             "Magento_Checkout/js/proceed-to-checkout": "Sapient_Worldpay/js/proceed-to-checkout",
             "Magento_Checkout/template/minicart/content.html": "Sapient_Worldpay/template/minicart/content.html",
             "Magento_Checkout/js/view/minicart": "Sapient_Worldpay/js/minicart",
-            "Magento_Checkout/js/view/billing-address.js": "Sapient_Worldpay/js/view/billing-address.js"
+            "Magento_Checkout/js/view/billing-address": "Sapient_Worldpay/js/view/billing-address"
         }
     }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -13,7 +13,7 @@ var config = {
             "Magento_Checkout/js/proceed-to-checkout": "Sapient_Worldpay/js/proceed-to-checkout",
             "Magento_Checkout/template/minicart/content.html": "Sapient_Worldpay/template/minicart/content.html",
             "Magento_Checkout/js/view/minicart": "Sapient_Worldpay/js/minicart",
-            "Magento_Checkout/js/view/billing-address": "Sapient_Worldpay/js/view/billing-address"
+            "Magento_Checkout/js/view/billing-address.js": "Sapient_Worldpay/js/view/billing-address.js"
         }
     }
 };

--- a/view/frontend/web/js/view/billing-address.js
+++ b/view/frontend/web/js/view/billing-address.js
@@ -57,11 +57,21 @@ function (
 
     return Component.extend({
         defaults: {
-            template: 'Magento_Checkout/billing-address'
+            template: 'Magento_Checkout/billing-address',
+            actionsTemplate: 'Magento_Checkout/billing-address/actions',
+            formTemplate: 'Magento_Checkout/billing-address/form',
+            detailsTemplate: 'Magento_Checkout/billing-address/details'
         },
         currentBillingAddress: quote.billingAddress,
         addressOptions: addressOptions,
         customerHasAddresses: addressOptions.length > 1,
+
+        /**
+         * Manage cancel button visibility
+         */
+        canUseCancelBillingAddress: ko.computed(function () {
+            return quote.billingAddress() || lastSelectedBillingAddress;
+        }),
 
         /**
          * Init component
@@ -134,9 +144,9 @@ function (
                 this.isAddressDetailsVisible(false);
             }
             checkoutData.setSelectedBillingAddress(null);
-            
-            
-            
+
+
+
         if (window.ApplePaySession) {
         //var merchantIdentifier = '<?=PRODUCTION_MERCHANTIDENTIFIER?>';
         var merchantIdentifier = window.checkoutConfig.payment.ccform.appleMerchantid;
@@ -146,7 +156,7 @@ function (
                    var wallets_APPLEPAY = document.getElementById("wallets_APPLEPAY-SSL");
                    var wallets_image_APPLEPAY = document.getElementById("wallets_image_APPLEPAY-SSL");
                    var wallets_label_APPLEPAY = document.getElementById("wallets_label_APPLEPAY-SSL");
-                   
+
                    if(wallets_APPLEPAY) {
                        //document.getElementById("wallets_APPLEPAY-SSL").style.display = "block";
                        document.getElementById("wallets_APPLEPAY-SSL").style.display = "inline";
@@ -157,13 +167,13 @@ function (
                    if(wallets_label_APPLEPAY) {
                        document.getElementById("wallets_label_APPLEPAY-SSL").style.display = "inline";
                    }
-                  
-                     
-               } 
-             }); 
-     } 
-                   
-                   
+
+
+               }
+             });
+     }
+
+
 
             return true;
         },
@@ -201,7 +211,7 @@ function (
                 }
             }
             this.updateAddresses();
-            
+
                    if (window.ApplePaySession) {
         //var merchantIdentifier = '<?=PRODUCTION_MERCHANTIDENTIFIER?>';
         var merchantIdentifier = window.checkoutConfig.payment.ccform.appleMerchantid;
@@ -211,7 +221,7 @@ function (
                    var wallets_APPLEPAY = document.getElementById("wallets_APPLEPAY-SSL");
                    var wallets_image_APPLEPAY = document.getElementById("wallets_image_APPLEPAY-SSL");
                    var wallets_label_APPLEPAY = document.getElementById("wallets_label_APPLEPAY-SSL");
-                   
+
                    if(wallets_APPLEPAY) {
                        //document.getElementById("wallets_APPLEPAY-SSL").style.display = "block";
                        document.getElementById("wallets_APPLEPAY-SSL").style.display = "inline";
@@ -222,14 +232,14 @@ function (
                    if(wallets_label_APPLEPAY) {
                        document.getElementById("wallets_label_APPLEPAY-SSL").style.display = "inline";
                    }
-                  
-                     
-               } 
-             }); 
-     } 
-            
-                  
-                  
+
+
+               }
+             });
+     }
+
+
+
         },
 
         /**
@@ -302,4 +312,4 @@ function (
             return _.isFunction(parent.getCode) ? parent.getCode() : 'shared';
         }
     });
-});                                                                                                                            
+});

--- a/view/frontend/web/js/view/billing-address.js
+++ b/view/frontend/web/js/view/billing-address.js
@@ -67,13 +67,6 @@ function (
         customerHasAddresses: addressOptions.length > 1,
 
         /**
-         * Manage cancel button visibility
-         */
-        canUseCancelBillingAddress: ko.computed(function () {
-            return quote.billingAddress() || lastSelectedBillingAddress;
-        }),
-
-        /**
          * Init component
          */
         initialize: function () {
@@ -130,6 +123,13 @@ function (
         },
 
         /**
+         * Manage cancel button visibility
+         */
+        canUseCancelBillingAddress: ko.computed(function () {
+            return quote.billingAddress() || lastSelectedBillingAddress;
+        }),
+
+        /**
          * @return {Boolean}
          */
         useShippingAddress: function () {
@@ -144,9 +144,9 @@ function (
                 this.isAddressDetailsVisible(false);
             }
             checkoutData.setSelectedBillingAddress(null);
-
-
-
+            
+            
+            
         if (window.ApplePaySession) {
         //var merchantIdentifier = '<?=PRODUCTION_MERCHANTIDENTIFIER?>';
         var merchantIdentifier = window.checkoutConfig.payment.ccform.appleMerchantid;
@@ -156,7 +156,7 @@ function (
                    var wallets_APPLEPAY = document.getElementById("wallets_APPLEPAY-SSL");
                    var wallets_image_APPLEPAY = document.getElementById("wallets_image_APPLEPAY-SSL");
                    var wallets_label_APPLEPAY = document.getElementById("wallets_label_APPLEPAY-SSL");
-
+                   
                    if(wallets_APPLEPAY) {
                        //document.getElementById("wallets_APPLEPAY-SSL").style.display = "block";
                        document.getElementById("wallets_APPLEPAY-SSL").style.display = "inline";
@@ -167,13 +167,13 @@ function (
                    if(wallets_label_APPLEPAY) {
                        document.getElementById("wallets_label_APPLEPAY-SSL").style.display = "inline";
                    }
-
-
-               }
-             });
-     }
-
-
+                  
+                     
+               } 
+             }); 
+     } 
+                   
+                   
 
             return true;
         },
@@ -211,7 +211,7 @@ function (
                 }
             }
             this.updateAddresses();
-
+            
                    if (window.ApplePaySession) {
         //var merchantIdentifier = '<?=PRODUCTION_MERCHANTIDENTIFIER?>';
         var merchantIdentifier = window.checkoutConfig.payment.ccform.appleMerchantid;
@@ -221,7 +221,7 @@ function (
                    var wallets_APPLEPAY = document.getElementById("wallets_APPLEPAY-SSL");
                    var wallets_image_APPLEPAY = document.getElementById("wallets_image_APPLEPAY-SSL");
                    var wallets_label_APPLEPAY = document.getElementById("wallets_label_APPLEPAY-SSL");
-
+                   
                    if(wallets_APPLEPAY) {
                        //document.getElementById("wallets_APPLEPAY-SSL").style.display = "block";
                        document.getElementById("wallets_APPLEPAY-SSL").style.display = "inline";
@@ -232,14 +232,14 @@ function (
                    if(wallets_label_APPLEPAY) {
                        document.getElementById("wallets_label_APPLEPAY-SSL").style.display = "inline";
                    }
-
-
-               }
-             });
-     }
-
-
-
+                  
+                     
+               } 
+             }); 
+     } 
+            
+                  
+                  
         },
 
         /**
@@ -312,4 +312,4 @@ function (
             return _.isFunction(parent.getCode) ? parent.getCode() : 'shared';
         }
     });
-});
+});                                                                                                                            


### PR DESCRIPTION
On checkout billing step, billing addresses are not rendered correctly. JS errors in console.
I found that current rewritten billing-address.js file has lack of dependencies which are present in original Magento file. And copied them from original file.
Also Magento tries to load ...billing-address/list.js file, that is absent in module. The reason of this is requirejs-config.js "map" config. That was changes to provide mapping just for needed file. 
Checked on Magento 2.3.5 commerce edition.