### PR TITLE
Fix checkout billing step rendering issues.

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -13,7 +13,7 @@ var config = {
             "Magento_Checkout/js/proceed-to-checkout": "Sapient_Worldpay/js/proceed-to-checkout",
             "Magento_Checkout/template/minicart/content.html": "Sapient_Worldpay/template/minicart/content.html",
             "Magento_Checkout/js/view/minicart": "Sapient_Worldpay/js/minicart",
-            "Magento_Checkout/js/view/billing-address": "Sapient_Worldpay/js/view/billing-address"
+            "Magento_Checkout/js/view/billing-address.js": "Sapient_Worldpay/js/view/billing-address.js"
         }
     }
 };

--- a/view/frontend/web/js/view/billing-address.js
+++ b/view/frontend/web/js/view/billing-address.js
@@ -57,7 +57,10 @@ function (
 
     return Component.extend({
         defaults: {
-            template: 'Magento_Checkout/billing-address'
+            template: 'Magento_Checkout/billing-address',
+            actionsTemplate: 'Magento_Checkout/billing-address/actions',
+            formTemplate: 'Magento_Checkout/billing-address/form',
+            detailsTemplate: 'Magento_Checkout/billing-address/details'
         },
         currentBillingAddress: quote.billingAddress,
         addressOptions: addressOptions,
@@ -118,6 +121,13 @@ function (
         addressOptionsText: function (address) {
             return address.getAddressInline();
         },
+
+        /**
+         * Manage cancel button visibility
+         */
+        canUseCancelBillingAddress: ko.computed(function () {
+            return quote.billingAddress() || lastSelectedBillingAddress;
+        }),
 
         /**
          * @return {Boolean}


### PR DESCRIPTION
On checkout billing step, billing addresses are not rendered correctly. JS errors in console.
I found that current rewritten billing-address.js file has lack of dependencies which are present in original Magento file. And copied them from original file.
Also Magento tries to load ...billing-address/list.js file, that is absent in module. The reason of this is requirejs-config.js "map" config. That was changes to provide mapping just for needed file.
Checked on Magento 2.3.5 commerce edition.