### PR TITLE
Worldpay Wallets  Payment Status Sync

### DIFF
--- a/Plugin/PluginBefore.php
+++ b/Plugin/PluginBefore.php
@@ -8,6 +8,7 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Backend\Block\Widget\Button\Toolbar as ToolbarContext;
 use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Backend\Block\Widget\Button\ButtonList;
+use Magento\Sales\Api\Data\OrderInterface;
 
 class PluginBefore
 {
@@ -33,10 +34,7 @@ class PluginBefore
             $orderId = $requestdata['order_id'];
             $syncurl = $this->_urlBuilder->getUrl("worldpay/syncstatus/index",array('order_id' => $orderId));
             $order = $this->order->load($orderId);
-            if($order->getPayment()->getMethod()=='worldpay_cc'
-                || $order->getPayment()->getMethod()=='worldpay_apm'
-                || $order->getPayment()->getMethod()=='worldpay_moto'
-                || $order->getPayment()->getMethod()=='worldpay_cc_vault') {
+            if($this->canSyncPaymentStatus($order)) {
                 $buttonList->add(
                     'sync_status',
                     ['label' => __('Sync Status'), 'onclick' => 'setLocation("'.$syncurl.'")', 'class' => 'reset'],
@@ -46,5 +44,29 @@ class PluginBefore
         }
 
         return [$context, $buttonList];
+    }
+
+    /**
+     * Checks whether we can sync the payment status for an order.
+     *
+     * @param OrderInterface $order
+     * @return bool
+     */
+    protected function canSyncPaymentStatus(OrderInterface $order)
+    {
+        $paymentMethod = $order->getPayment()->getMethod();
+
+        switch ($paymentMethod) {
+            case 'worldpay_cc':
+            case 'worldpay_apm':
+            case 'worldpay_moto':
+            case 'worldpay_cc_vault':
+            case 'worldpay_wallets':
+                return true;
+                break;
+            default:
+                return false;
+                break;
+        }
     }
 }


### PR DESCRIPTION
Hi

Currently, orders placed via the **worldpay_wallets** payment method cannot have their payment status synchronised via the backend of Magento.

This PR resolves that issue.