### PR TITLE
Correct Subtract Date Interval

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -984,7 +984,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getSavedCardsCount($customerId)
     {
         $now = new \DateTime();
-        $lastDay = new  \DateInterval(sprintf('P%dD', 1));
+        $lastDay = $now->sub(new \DateInterval(sprintf('P%dD', 1)));
         $savedCards = $this->_savecard->create()->getCollection()
                         ->addFieldToSelect(['id'])
                         ->addFieldToFilter('customer_id', ['eq' => $customerId])


### PR DESCRIPTION
The following method to lookup a customer's saved cards count is broken.

https://github.com/Worldpay/Worldpay-Magento2-CG/blob/master/Helper/Data.php#L987

This is due to the DateInterval not being subtracted from the current date properly leading to the following error:

SQLSTATE[HY000]: General error: 1525 Incorrect TIMESTAMP value: 'Y-m-d H:i:s', query was: SELECT main_table.id, main_table.id FROM worldpay_token AS main_table WHERE (customer_id = 1) AND (created_at <= '2020-09-23 10:21:43') AND (created_at >= 'Y-m-d H:i:s')

Fix is the following:

`$now = new \DateTime();`
`$lastDay = $now->sub(new \DateInterval(sprintf('P%dD', 1)));`

See:

https://github.com/Worldpay/Worldpay-Magento2-CG/issues/41