### PR TITLE
Adds missing curly bracket in saved card form

### DIFF
--- a/view/frontend/web/template/payment/saved-card-form.html
+++ b/view/frontend/web/template/payment/saved-card-form.html
@@ -49,7 +49,7 @@
                value=""
                data-bind="attr: {id: getCode() + '_cc_cid',
                           title: $t('Card Verification Number'),
-                          'data-container': getCode() + '-cc-cvv'},
+                          'data-container': getCode() + '-cc-cvv',
                           enable: isActive($parents),
                           value: SavedcreditCardVerificationNumber}"
                />

--- a/view/frontend/web/template/payment/saved-card-form.html
+++ b/view/frontend/web/template/payment/saved-card-form.html
@@ -51,7 +51,7 @@
                           title: $t('Card Verification Number'),
                           'data-container': getCode() + '-cc-cvv'},
                           enable: isActive($parents),
-                          value: SavedcreditCardVerificationNumber"
+                          value: SavedcreditCardVerificationNumber}"
                />
         <div class="field-tooltip toggle">
             <span class="field-tooltip-action action-cvv"


### PR DESCRIPTION
There's a curly bracket missing in one of the fields of the saved card form. Without it, the js fails and all the fields show up, breaking the form.