### PR TITLE
Added accepted payment types to paymentmethod.xml 

### DIFF
--- a/etc/paymentmethods.xml
+++ b/etc/paymentmethods.xml
@@ -330,6 +330,13 @@
                 </areas>
                 <capture_request>1</capture_request>
             </VISA-SSL>
+            <VISA_COMMERCIAL-SSL>
+                <title>Visa Commercial</title>
+                <areas>
+                    <area>GLOBAL</area>
+                </areas>
+                <capture_request>1</capture_request>
+            </VISA_COMMERCIAL-SSL>
             <ECMC-SSL>
                 <title>MasterCard</title>
                 <areas>
@@ -337,6 +344,13 @@
                 </areas>
                 <capture_request>1</capture_request>
             </ECMC-SSL>
+            <ECMC_COMMERCIAL-SSL>
+                <title>MasterCard Commercial</title>
+                <areas>
+                    <area>GLOBAL</area>
+                </areas>
+                <capture_request>1</capture_request>
+            </ECMC_COMMERCIAL-SSL>
             <CB-SSL>
                 <title>Carte Bancaire</title>
                 <areas>

--- a/etc/paymentmethods.xml
+++ b/etc/paymentmethods.xml
@@ -242,6 +242,13 @@
                 </areas>
                 <capture_request>1</capture_request>
             </VISA-SSL>
+            <VISA_COMMERCIAL-SSL>
+                <title>Visa</title>
+                <areas>
+                    <area>GLOBAL</area>
+                </areas>
+                <capture_request>1</capture_request>
+            </VISA_COMMERCIAL-SSL>
             <ECMC-SSL>
                 <title>MasterCard</title>
                 <areas>
@@ -249,6 +256,13 @@
                 </areas>
                 <capture_request>1</capture_request>
             </ECMC-SSL>
+            <ECMC_COMMERCIAL-SSL>
+                <title>MasterCard</title>
+                <areas>
+                    <area>GLOBAL</area>
+                </areas>
+                <capture_request>1</capture_request>
+            </ECMC_COMMERCIAL-SSL>
             <CB-SSL>
                 <title>Carte Bancaire</title>
                 <areas>

--- a/etc/paymentmethods.xml
+++ b/etc/paymentmethods.xml
@@ -243,7 +243,7 @@
                 <capture_request>1</capture_request>
             </VISA-SSL>
             <VISA_COMMERCIAL-SSL>
-                <title>Visa</title>
+                <title>Visa Commercial</title>
                 <areas>
                     <area>GLOBAL</area>
                 </areas>
@@ -257,7 +257,7 @@
                 <capture_request>1</capture_request>
             </ECMC-SSL>
             <ECMC_COMMERCIAL-SSL>
-                <title>MasterCard</title>
+                <title>MasterCard Commercial</title>
                 <areas>
                     <area>GLOBAL</area>
                 </areas>


### PR DESCRIPTION
Confirmed a couple credit card types, visa commercial, and ecmc (mastercard) commercial, represented by the payment methods VISA_COMMERCIAL-SSL, AND ECMC_COMMERCIAL-SSL, are accepted and thus should be capture-able. Currently these payment types do not exist under the worldpay_cc, and worldpay_cc_vault types within the paymentmethod.xml, and fail to capture, silently. 

I'd also recommend checking what others are potentially missing, as anything not listed under the types section will not capture properly, and do not fail by any Magento standards, resulting in authorized, but not captured transactions on the worldpay side, and "complete" transactions on the Magento side.

In reference to the capture request functionality, the paymentmethod.xml is referenced here: https://github.com/Worldpay/Worldpay-Magento2-CG/blob/master/Model/Utilities/PaymentMethods.php#L211-L223
