### PR TITLE
Remove invalid attributes from db_schema.xml varchar columns

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -2,7 +2,7 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
   <table name="worldpay_payment" resource="default" engine="innodb" comment="Payment Table">
     <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true" comment="Id"/>
-    <column xsi:type="varchar" name="order_id" padding="10" unsigned="true" nullable="false" identity="false" comment="Order Id" length="25"/>
+    <column xsi:type="varchar" name="order_id" nullable="false" comment="Order Id" length="25"/>
     <column xsi:type="varchar" name="payment_status" nullable="true" length="255" comment="Payment Status"/>
     <column xsi:type="varchar" name="payment_model" nullable="false" length="25" comment="Payment Model"/>
     <column xsi:type="varchar" name="payment_type" nullable="false" length="255" comment="Payment Type"/>
@@ -97,7 +97,7 @@
   </table>
   <table name="worldpay_notification_history" resource="default" engine="innodb" comment="Worldpay Notification History">
     <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true" comment="Id"/>
-    <column xsi:type="varchar" name="order_id" padding="10" unsigned="true" nullable="true" identity="false" comment="Worldpay order id" onCreate="migrateDataFrom(order_id)" length="255"/>
+    <column xsi:type="varchar" name="order_id" nullable="true" comment="Worldpay order id" onCreate="migrateDataFrom(order_id)" length="255"/>
     <column xsi:type="varchar" name="status" nullable="true" length="255" comment="Status"/>
     <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Created At"/>
     <constraint xsi:type="primary" referenceId="PRIMARY">


### PR DESCRIPTION
Hello,

I've been running into an error when trying to install the latest release of this module (2.4.3-p0322) against Magento 2 Community (tried with versions 2.4.3-p1 and 2.4.3-p2).

The following occurs during `bin/magento setup:upgrade`:

```
Schema creation/updates:
The XML in file "/app/vendor/sapient/module-worldpay/etc/db_schema.xml" is invalid:
Element 'column', attribute 'padding': The attribute 'padding' is not allowed.
Line: 5

Element 'column', attribute 'unsigned': The attribute 'unsigned' is not allowed.
Line: 5

Element 'column', attribute 'identity': The attribute 'identity' is not allowed.
Line: 5

Element 'column', attribute 'padding': The attribute 'padding' is not allowed.
Line: 100

Element 'column', attribute 'unsigned': The attribute 'unsigned' is not allowed.
Line: 100

Element 'column', attribute 'identity': The attribute 'identity' is not allowed.
Line: 100

Verify the XML and try again.
```

The columns specified on line 5 and 100 are both type `varchar`, and I don't think those attributes are valid against M2's XSD - https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/types/texts/varchar.xsd.

I've removed these attributes and attempted installation locally, which completes successfully.