### PR TITLE
Make method compatible with parent method in PHP 8

### DIFF
--- a/Logger/WorldpayLogger.php
+++ b/Logger/WorldpayLogger.php
@@ -6,7 +6,7 @@ namespace Sapient\Worldpay\Logger;
 
 class WorldpayLogger extends \Monolog\Logger
 {
-    public function addRecord($level, $message, array $context = [])
+    public function addRecord(int $level, string $message, array $context = []): bool
     {
         $ObjectManager = \Magento\Framework\App\ObjectManager::getInstance();
         $logEnabled = (bool) $ObjectManager->get(\Magento\Framework\App\Config\ScopeConfigInterface::class)


### PR DESCRIPTION
Declare addRecord method to be compatible with the parent method: https://github.com/Seldaek/monolog/blob/main/src/Monolog/Logger.php#L292 to support PHP 8 for magento 2.4.4