### PR TITLE
Fix issue where database table prefix is ignored

### DIFF
--- a/Model/ResourceModel/Recurring/Subscription/Collection.php
+++ b/Model/ResourceModel/Recurring/Subscription/Collection.php
@@ -21,6 +21,13 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
     private $storeManager;
 
     /**
+     * Resource connection
+     *
+     * @var \Magento\Framework\App\ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
      * Flag that indicates if plans table has been joined
      *
      * @var bool
@@ -34,6 +41,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      * @param \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\App\ResourceConnection $resourceConnection
      * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
      * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource
      */
@@ -43,10 +51,12 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy,
         \Magento\Framework\Event\ManagerInterface $eventManager,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\App\ResourceConnection $resourceConnection,
         \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
         \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         $this->storeManager = $storeManager;
+        $this->resourceConnection = $resourceConnection;
         parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
     }
 
@@ -111,7 +121,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         }
 
         $this->getSelect()->joinLeft(
-            ['plans' => 'worldpay_recurring_plans'],
+            ['plans' => $this->resourceConnection->getTableName('worldpay_recurring_plans')],
             'plans.plan_id = main_table.plan_id',
             $cols
         )->columns(

--- a/Model/ResourceModel/Recurring/Subscription/Grid/Collection.php
+++ b/Model/ResourceModel/Recurring/Subscription/Grid/Collection.php
@@ -22,6 +22,7 @@ class Collection extends SubscriptionCollection implements SearchResultInterface
      * @param \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\App\ResourceConnection $resourceConnection
      * @param string $eventPrefix
      * @param string $eventObject
      * @param string $model
@@ -36,6 +37,7 @@ class Collection extends SubscriptionCollection implements SearchResultInterface
         \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy,
         \Magento\Framework\Event\ManagerInterface $eventManager,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\App\ResourceConnection $resourceConnection,
         $eventPrefix,
         $eventObject,
         $model = \Magento\Framework\View\Element\UiComponent\DataProvider\Document::class,
@@ -48,6 +50,7 @@ class Collection extends SubscriptionCollection implements SearchResultInterface
             $fetchStrategy,
             $eventManager,
             $storeManager,
+            $resourceConnection,
             $connection,
             $resource
         );


### PR DESCRIPTION
Fixes #110 to ensure that the table join in `Model/ResourceModel/Recurring/Subscription/Collection.php` uses the correct table name including any configured prefix.