### PR TITLE
"Synchronize Order Status" - resolves #135

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -277,44 +277,48 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
     }
+
     /**
      * Get Xml Username
      *
      * @param string $paymentType
+     * @param int|null $storeId
      * @return string
      */
-    public function getXmlUsername($paymentType)
+    public function getXmlUsername($paymentType, $storeId = null)
     {
         if ($paymentType) {
-            $merchat_detail = $this->merchantprofile->getConfigValue($paymentType);
-            $merchantCodeValue = $merchat_detail?$merchat_detail['merchant_username']:'';
-            if (!empty($merchantCodeValue)) {
-                return $merchantCodeValue;
+            $merchantDetail = $this->merchantprofile->getConfigValue($paymentType);
+            if (!empty($merchantDetail['merchant_username'])) {
+                return $merchantDetail['merchant_username'];
             }
         }
         return $this->_scopeConfig->getValue(
             'worldpay/general_config/xml_username',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeId
         );
     }
+
     /**
      * Get Xml Password
      *
      * @param string $paymentType
+     * @param int|null $storeId
      * @return string
      */
-    public function getXmlPassword($paymentType)
+    public function getXmlPassword($paymentType, $storeId = null)
     {
         if ($paymentType) {
-            $merchat_detail = $this->merchantprofile->getConfigValue($paymentType);
-            $merchantCodeValue = $merchat_detail?$merchat_detail['merchant_password']:'';
-            if (!empty($merchantCodeValue)) {
-                return $merchantCodeValue;
+            $merchantDetail = $this->merchantprofile->getConfigValue($paymentType);
+            if (!empty($merchantDetail['merchant_password'])) {
+                return $merchantDetail['merchant_password'];
             }
         }
         return $this->_scopeConfig->getValue(
             'worldpay/general_config/xml_password',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeId
         );
     }
     /**

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -111,7 +111,7 @@ class Order
      */
     public function getStoreId()
     {
-        return $this->getOrder()->getPayment()->getStoreId();
+        return $this->getOrder()->getStoreId();
     }
 
     /**

--- a/Model/Payment/Service.php
+++ b/Model/Payment/Service.php
@@ -162,7 +162,7 @@ class Service
         $rawXml = $this->paymentservicerequest->inquiry(
             $worldPayPayment->getMerchantId(),
             $worldPayPayment->getWorldpayOrderId(),
-            $worldPayPayment->getStoreId(),
+            $order->getStoreId(),
             $order->getPaymentMethodCode(),
             $worldPayPayment->getPaymentType(),
             $interactionType

--- a/Model/Request/PaymentServiceRequest.php
+++ b/Model/Request/PaymentServiceRequest.php
@@ -1136,8 +1136,8 @@ class PaymentServiceRequest extends \Magento\Framework\DataObject
     {
         $this->_wplogger->info('########## Submitting order inquiry. OrderCode: (' . $orderCode . ') ##########');
         $this->_wplogger->info('## Interaction Type'.$interactionType);
-        $xmlUsername = $this->worldpayhelper->getXmlUsername($paymenttype);
-        $xmlPassword = $this->worldpayhelper->getXmlPassword($paymenttype);
+        $xmlUsername = $this->worldpayhelper->getXmlUsername($paymenttype, $storeId);
+        $xmlPassword = $this->worldpayhelper->getXmlPassword($paymenttype, $storeId);
         $merchantcode = $merchantCode;
         
         if ($interactionType === 'MOTO') {


### PR DESCRIPTION
Fix for #135 

- Introduce the variable $storeId in the methods getXmlUsername() and getXmlPassword within the specified class.

- Incorporate the $storeId parameter into the username and password requests within the inquiry() function of \Sapient\Worldpay\Model\Request\PaymentServiceRequest::inquiry().

- Modify the behaviour of the getStoreId() method in the \Sapient\Worldpay\Model\Order::getStoreId() class to return the Store ID of the order, considering that Payment objects do not have an associated StoreId.

- Replace references to $worldPayPayment->getStoreId() with $order->getStoreId() in the getPaymentUpdateXmlForOrder() function of \Sapient\Worldpay\Model\Payment\Service, which invokes the inquiry() function.